### PR TITLE
We need some sub-projects to have WIP coverage testing

### DIFF
--- a/monolithic/repository/cart/build.gradle
+++ b/monolithic/repository/cart/build.gradle
@@ -51,6 +51,9 @@ jacocoTestReport {
 jacocoTestCoverageVerification {
     Map<String, String> env = System.getenv()
     def coverage = (env.get('COVERAGE') != null ? Float.parseFloat(env.get('COVERAGE')) : 0.3 )
+    // This module testing dev is still WIP, lets validate when
+    // coverage check is less than 0.15, otherwise we always have 0 validation
+    coverage = (coverage < 0.15) ? coverage : 0.0
 
     violationRules {
         rule {

--- a/monolithic/repository/product/build.gradle
+++ b/monolithic/repository/product/build.gradle
@@ -51,6 +51,9 @@ jacocoTestReport {
 jacocoTestCoverageVerification {
     Map<String, String> env = System.getenv()
     def coverage = (env.get('COVERAGE') != null ? Float.parseFloat(env.get('COVERAGE')) : 0.3 )
+    // This module testing dev is still WIP, lets validate when
+    // coverage check is less than 0.15, otherwise we always have 0 validation
+    coverage = (coverage < 0.15) ? coverage : 0.0
 
     violationRules {
         rule {

--- a/monolithic/service/cart/build.gradle
+++ b/monolithic/service/cart/build.gradle
@@ -52,6 +52,9 @@ jacocoTestReport {
 jacocoTestCoverageVerification {
     Map<String, String> env = System.getenv()
     def coverage = (env.get('COVERAGE') != null ? Float.parseFloat(env.get('COVERAGE')) : 0.3 )
+    // This module testing dev is still WIP, lets validate when
+    // coverage check is less than 0.15, otherwise we always have 0 validation
+    coverage = (coverage < 0.15) ? coverage : 0.0
 
     violationRules {
         rule {

--- a/monolithic/ui/build.gradle
+++ b/monolithic/ui/build.gradle
@@ -178,6 +178,9 @@ jacocoTestReport {
 jacocoTestCoverageVerification {
     Map<String, String> env = System.getenv()
     def coverage = (env.get('COVERAGE') != null ? Float.parseFloat(env.get('COVERAGE')) : 0.3 )
+    // This module testing dev is still WIP, lets validate when
+    // coverage check is less than 0.15, otherwise we always have 0 validation
+    coverage = (coverage < 0.15) ? coverage : 0.0
 
     violationRules {
         rule {


### PR DESCRIPTION
Not all the sub-projects are ready for full coverage testing, so we're 
reducing the testing point lower than the highest testing point for 
other projects so that they always pass in favor of projects that are 
ready. If we test below that limit, then testing coverage can apply for 
these sub projects.