### PR TITLE
Update monolithic/ui/build.gradle

### DIFF
--- a/monolithic/ui/build.gradle
+++ b/monolithic/ui/build.gradle
@@ -149,8 +149,8 @@ war {
 }
 
 docker {
-    maintainer = 'Bernd Zuther <bernd.zuther@codecentric.de>'
-    baseImage = 'wegenenverkeer/tomcat7-java8'
+    maintainer = 'Microsoft Lab'
+    baseImage = 'maluuba/tomcat7-java8'
 }
 
 task packageToContainer(type: Docker) {


### PR DESCRIPTION
Due to missing wegenenverkeer/tomcat7-java8 image at docker hub, last task in the Final assessment can't be performed.
Update monolithic/ui/build.gradle to use different image repo which is maintained by Microsoft.